### PR TITLE
feat: 更新確認の定期実行を18時に変更

### DIFF
--- a/.github/workflows/check_update.yml
+++ b/.github/workflows/check_update.yml
@@ -2,7 +2,7 @@ name: check-update
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 3 * * 1,3,5" # JSTで毎週月・水・金曜12:00に実行
+    - cron: "0 9 * * 1,3,5" # JSTで毎週月・水・金曜18:00に実行
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
公式お知らせの更新が15時前後が多い