### PR TITLE
[Feature Request] 駅メモ公式データとの比較テストをより高頻度に実行したい

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -1,0 +1,31 @@
+name: download
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 1 * *" # JSTで毎月１日18:00に実行（低頻度）
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: "npm"
+      - name: setup node modules
+        run: npm install
+      - name: download
+        run: |
+          mkdir -p src/ekimemo/station src/ekimemo/line
+          rm -f src/ekimemo/station/* src/ekimemo/line/*
+          npm run download
+      - name: cache downloaded data
+        if: success()
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            src/ekimemo/station
+            src/ekimemo/line
+          key: ekimemo-data-latest

--- a/.github/workflows/ekimemo.yml
+++ b/.github/workflows/ekimemo.yml
@@ -2,13 +2,22 @@ name: ekimemo
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 9 1 * *" # JSTで毎月１日18:00に実行
+    - cron: "0 12 1 * *" # JSTで毎月１日21:00に実行（ダウンロード完了から3時間後）
+  pull_request:
+    branches: [ main ]
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: restore cached data
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            src/ekimemo/station
+            src/ekimemo/line
+          key: ekimemo-data-latest
       - name: setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -16,10 +25,5 @@ jobs:
           cache: "npm"
       - name: setup node modules
         run: npm install
-      - name: download
-        run: |
-          mkdir -p src/ekimemo/station src/ekimemo/line
-          rm -f src/ekimemo/station/* src/ekimemo/line/*
-          npm run download
       - name: run test
         run: npm run test-ekimemo


### PR DESCRIPTION
# 概要

#175 #176 など予期しない差分が見つかる場合もあるので、可能ならより高頻度に実施したい

## 問題

比較データのダウンロードに長時間（1時間程度）を要するため、気軽に実行できない
現在のPRでも実行せず、代わりに定期実行（月初め）のみ

## 提案

ダウンロードとテストを分離する

- ダウンロードは低頻度の定期実行のままにして、データを cache として保存しておく
- cachet を利用してテストはより高い頻度で実行可能になる